### PR TITLE
fix(actor): Appium(AssertElementNotVisible) doesn't work as in absence of 'swipe' argument

### DIFF
--- a/actor/appium/src/main/java/org/getopentest/appium/core/AppiumTestAction.java
+++ b/actor/appium/src/main/java/org/getopentest/appium/core/AppiumTestAction.java
@@ -385,8 +385,16 @@ public abstract class AppiumTestAction extends TestAction {
     protected void swipe(SwipeOptions options) {
         if (options.direction.equals("none")) {
             if (options.targetElement != null) {
-                if (checkCondition(options.targetElement, options.condition, AppiumHelper.getExplicitWaitSec())) {
-                    return;
+                if (options.condition == Condition.INVISIBILITY) {
+                    if (!checkCondition(options.targetElement, Condition.INVISIBILITY, AppiumHelper.getExplicitWaitSec())) {
+                        throw new RuntimeException(String.format(
+                                "Element %s was found to be visible, which is not what we were expecting",
+                                options.targetElement));
+                    }
+                } else {
+                    if (checkCondition(options.targetElement, options.condition, AppiumHelper.getExplicitWaitSec())) {
+                        return;
+                    }
                 }
             } else {
                 return;


### PR DESCRIPTION
…in absense of swipe argument.