### PR TITLE
fix(appium): swipe logic for iOS should use absolute coordinates

### DIFF
--- a/actor/appium/src/main/java/org/getopentest/appium/core/AppiumTestAction.java
+++ b/actor/appium/src/main/java/org/getopentest/appium/core/AppiumTestAction.java
@@ -351,7 +351,7 @@ public abstract class AppiumTestAction extends TestAction {
     }
 
     protected void swipe(int fromX, int fromY, int toX, int toY, int durationMs) {
-        if (AppiumHelper.isPlatform("ios") && AppiumHelper.getConfig().getBoolean("appium.useRelativeCoordsIos", true)) {
+        if (AppiumHelper.isPlatform("ios") && AppiumHelper.getConfig().getBoolean("appium.useRelativeCoordsIos", false)) {
             // In Appium 1.7.1, the TouchAction.moveTo() method assumes absolute
             // coordinates for Android but relative coordinates for iOS. The mess that
             // follows below is necessary to work around this inconsistency.


### PR DESCRIPTION
The “appium.useRelativeCoordsIos” parameter's default value is set to “true”, which causes the swipe logic to use relative coordinates (compatible with Appium 1.7.1). The default swipe logic should use use absolute coordinates, as expected by Appium ^1.8.0.
