### PR TITLE
feat(build): specify environment in cli

### DIFF
--- a/build/module-opentest/opentest.js
+++ b/build/module-opentest/opentest.js
@@ -98,7 +98,7 @@ yargs
     })
     .command('session', 'Test session commands', function (yargs) {
         yargs.command(
-            'create [template] [wait] [server]',
+            'create [template] [wait] [server] [out] [env]',
             'Creates a new test session',
             function (yargs) {
                 yargs.options('out', {
@@ -124,6 +124,12 @@ yargs
                     describe: 'Sets how long to wait for the session to complete before timing out, in seconds.',
                     type: 'string'
                 });
+
+                yargs.options('env', {
+                    alias: 'e',
+                    describe: 'The environment to run the tests against.',
+                    type: 'string'
+                });
             },
             function (argv) {
                 // When the wait option is specified without a value,
@@ -135,12 +141,14 @@ yargs
                     }
                     session.createSessionFromTemplateAndWait(argv.template, {
                         server: argv.server,
+                        environment: argv.env,
                         timeout: timeout,
                         outFile: argv.out
                     });
                 } else {
                     session.createSessionFromTemplate(argv.template, {
-                        server: argv.server
+                        server: argv.server,
+                        environment: argv.env
                     });
                 }
             });

--- a/build/module-opentest/session.js
+++ b/build/module-opentest/session.js
@@ -50,6 +50,9 @@ function createSessionFromTemplate(templatePartialPath, options) {
 			}
 		}
 	};
+	if (options.environment) {
+		reqOptions.data.environment = options.environment;
+	}
 
 	return new Promise(function (resolve, reject) {
 		axios(reqOptions)
@@ -70,7 +73,8 @@ function createSessionFromTemplate(templatePartialPath, options) {
 
 /**
  * Create a new test session from a template file and waits for the test
- * session to complete before returning. Options: timeout, server, outFile.*/
+ * session to complete before returning. Options: timeout, server, outFile,
+ * environment.*/
 function createSessionFromTemplateAndWait(templatePartialPath, options) {
 	options = options || {};
 	const timeout = options.timeout || 7200;
@@ -79,8 +83,12 @@ function createSessionFromTemplateAndWait(templatePartialPath, options) {
 	if (typeof options.outFile === 'string' || options.outFile instanceof String) {
 		outFile = helpers.trimChars(options.outFile);
 	}
+	const createOptions = { server: syncServerUrl };
+	if (options.environment) {
+		createOptions.environment = options.environment;
+	}
 
-	createSessionFromTemplate(templatePartialPath, { server: syncServerUrl })
+	createSessionFromTemplate(templatePartialPath, createOptions)
 		.then(function (sessionId) {
 			let startTime = Date.now();
 


### PR DESCRIPTION
Add env option to opentest session cli command to allow specification of execution environment

close #164