### PR TITLE
fix(server): handle includeTestsWithTags in ui

### DIFF
--- a/server/src/public/js/ng/root-ctrl.js
+++ b/server/src/public/js/ng/root-ctrl.js
@@ -12,6 +12,7 @@ ngApp.controller('LayoutCtrl', ['$scope', '$http', '$rootScope', 'apiAdapter', '
 		moment: moment,
 		replaySession: replaySession,
 		selectedEnvironment: null,
+		selectedIncludeTestsWithTags: null,
 		selectedTemplate: null,
 		selectedTestsCount: 0,
 		sessionLabel: null,
@@ -113,7 +114,7 @@ ngApp.controller('LayoutCtrl', ['$scope', '$http', '$rootScope', 'apiAdapter', '
 	function createTestSession() {
 		var tests = $scope.vm.tests.filter(function (t) { return t.selected; });
 
-		if (!tests.length) { return; }
+		if (!tests.length && !$scope.vm.selectedIncludeTestsWithTags) { return; }
 
 		var testInfos = tests.map(function (test) {
 			return {
@@ -148,9 +149,17 @@ ngApp.controller('LayoutCtrl', ['$scope', '$http', '$rootScope', 'apiAdapter', '
 			actorTags: actorTags,
 			environment: $scope.vm.selectedEnvironment || '',
 			maxIterations: $('#session-iterations').val(),
-			sessionLabel: $scope.vm.sessionLabel,
-			tests: testInfos
+			sessionLabel: $scope.vm.sessionLabel
 		};
+
+		if ($scope.vm.selectedIncludeTestsWithTags) {
+			reqBody.template = {
+				name: $scope.vm.selectedTemplate.name,
+				path: $scope.vm.selectedTemplate.path
+			};
+		} else {
+			reqBody.tests = testInfos;
+		}
 
 		$http.post('/api/session', reqBody)
 			.then(
@@ -168,32 +177,39 @@ ngApp.controller('LayoutCtrl', ['$scope', '$http', '$rootScope', 'apiAdapter', '
 				session = session || uiSession;
 				$scope.vm.sessionLabel = apiAdapter.computeDuplicateSessionLabel(session.label || session.sessionLabel);
 
-				// Remove the iteration number from the end of the test name
-				// for data-driven tests
-				$scope.vm.selectedTests = session.tests.map(function (test) {
-					var match = test.name.match(/^(.*) \[\d+\]$/);
-					if (match) {
-						var originalTestName = match[1];
-						test.name = originalTestName;
-					}
-					return test;
-				});
-
-				// Remove the duplicate names that will appear for test
-				// sessions containing data-driven tests
-				var uniqueTestNames = [];
-				$scope.vm.selectedTests =
-					$scope.vm.selectedTests.filter(function (test) {
-						var curatedPath = (test.path || '').replace(/^\/|\/$/g, '');
-						var testFullName = curatedPath + '/' + test.name;
-						if (uniqueTestNames.indexOf(testFullName) < 0) {
-							uniqueTestNames.push(testFullName);
-							return true;
+				// Only filter the tests if they exist
+				// There could be no tests in the case of includeTestsWithTag template
+				if (session.tests) {
+					// Remove the iteration number from the end of the test name
+					// for data-driven tests
+					$scope.vm.selectedTests = session.tests.map(function (test) {
+						var match = test.name.match(/^(.*) \[\d+\]$/);
+						if (match) {
+							var originalTestName = match[1];
+							test.name = originalTestName;
 						}
+						return test;
 					});
+
+					// Remove the duplicate names that will appear for test
+					// sessions containing data-driven tests
+					var uniqueTestNames = [];
+					$scope.vm.selectedTests =
+						$scope.vm.selectedTests.filter(function (test) {
+							var curatedPath = (test.path || '').replace(/^\/|\/$/g, '');
+							var testFullName = curatedPath + '/' + test.name;
+							if (uniqueTestNames.indexOf(testFullName) < 0) {
+								uniqueTestNames.push(testFullName);
+								return true;
+							}
+						});
+				} else {
+					$scope.vm.selectedTests = [];
+				}
 				$scope.vm.iterations = (session.maxIterations || 1).toString();
 				$scope.vm.actorTags = session.actorTags;
 				$scope.vm.selectedEnvironment = session.environment || null;
+				$scope.vm.selectedIncludeTestsWithTags = session.includeTestsWithTags;
 				$('#create-session').modal('show');
 			})
 			.catch(function (err) {
@@ -209,6 +225,7 @@ ngApp.controller('LayoutCtrl', ['$scope', '$http', '$rootScope', 'apiAdapter', '
 				sessionLabel: $scope.vm.selectedTemplate.sessionLabel,
 				iterations: $scope.vm.selectedTemplate.iterations,
 				actorTags: $scope.vm.selectedTemplate.actorTags,
+				includeTestsWithTags: $scope.vm.selectedTemplate.includeTestsWithTags,
 				tests: $scope.vm.selectedTemplate.tests
 			};
 			editSession(session);

--- a/server/src/public/js/ng/root-ctrl.js
+++ b/server/src/public/js/ng/root-ctrl.js
@@ -243,6 +243,7 @@ ngApp.controller('LayoutCtrl', ['$scope', '$http', '$rootScope', 'apiAdapter', '
 		$('#create-session').on('hidden.bs.modal', function () {
 			$scope.vm.isLoadingTestInfo = true;
 			$scope.vm.tests = [];
+			$scope.vm.selectedIncludeTestsWithTags = null;
 			helpers.safeApply($scope);
 		});
 

--- a/server/src/views/layout.pug
+++ b/server/src/views/layout.pug
@@ -141,15 +141,14 @@ html
                                     input.form-control(type="text" ng-model="vm.actorTags" placeholder="Actor tags" title="Actor tags")
                             div.vspace-double
                             div.row(style="padding-top: 15px; padding-bottom: 10px")
-                                div.col-md-6
+                                div.col-md-12(style="font-size: 16px", ng-show='vm.selectedIncludeTestsWithTags')
+                                    span Include tests with tags: {{ vm.selectedIncludeTestsWithTags }}
+                                div.col-md-6(ng-hide='vm.selectedIncludeTestsWithTags')
                                     div
                                         i.fas.fa-search(style="font-size: 16px; margin-left: 3px; margin-top: 10px; position: absolute; z-index: 999")
                                         input.form-control.search-test(type="text" ng-model="vm.searchText" placeholder="Search" title="Search")
                                         a(type="button" href="#" ng-click="vm.searchText = ''" ng-show="vm.searchText" style="position: absolute;top: 0px; right: 0px; opacity: 0.7; font-size: 1.5em; width: 15px") ×
-                                div.col-md-3(style="font-size: 16px")
-                                    //- input(id="only-selected" type="checkbox")
-                                    //- label(for="only-selected") Show only selected
-                                div.col-md-3
+                                div.col-md-6(ng-hide='vm.selectedIncludeTestsWithTags')
                                     span(style="font-size: 16px").pull-right {{ vm.selectedTestsCount }} tests selected
                             div.vspace-double
                             div.vspace-double
@@ -160,7 +159,7 @@ html
                             //- Progress indicator
                             div.progress-indicator(ng-show='vm.isLoadingTestInfo')
                                 div.img
-                            table.table.table-condensed.table-hover(ng-cloak ng-hide="!vm.tests.length" style="table-layout: fixed; word-wrap: break-word;")
+                            table.table.table-condensed.table-hover(ng-cloak ng-hide="!vm.tests.length || vm.selectedIncludeTestsWithTags" style="table-layout: fixed; word-wrap: break-word;")
                                 //thead
                                     th(style="width: 40px;")
                                     th(style="width: 40%;") Test Name


### PR DESCRIPTION
Modify edit-template modal and create-session call to properly
handle templates with includeTestsWithTags feature that do not
contain any explicitly listed tests

close #175