### PR TITLE
Add filter for test session creation from template

### DIFF
--- a/server/src/views/layout.pug
+++ b/server/src/views/layout.pug
@@ -17,7 +17,7 @@ html
             |   <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
             |   <script src="https://oss.maxcdn.com/libs/respond.js/1.3.0/respond.min.js"></script>
             | <![endif]-->
-            
+
             script(src=`${urlPrefix}/js/lib/jquery.min.js`)
             script(src=`${urlPrefix}/js/lib/angular.min.js`)
             script(src=`${urlPrefix}/js/lib/bootstrap.min.js`)
@@ -47,7 +47,7 @@ html
                             a(href=`${urlPrefix || '/'}`) Home
                         li.dropdown(style=(readOnlyView ? 'display: none' : ''))
                             a.dropdown-toggle(href="#" data-toggle="dropdown")
-                                | Session 
+                                | Session
                                 span.caret
                             ul.dropdown-menu
                                 li
@@ -56,7 +56,7 @@ html
                                     a(href="#" data-toggle="modal" data-target="#create-from-template") Create Session From Template...
                         li
                             a(href="https://getopentest.org" target="_blank") Docs
-                            
+
                     //- Variables "version", "buildDate" and "commitSha" are
                     //- injected into the view's context by Express.
                     - var commitSuffixMatch = (commitSha && commitSha.match(/-.*/)) || null;
@@ -78,17 +78,24 @@ html
                         button.close(data-dismiss="modal") &times;
                         p.modal-title Create Test Session from Template
                     div.modal-body
-                        button.btn.btn-secondary(ng-click="vm.createSessionFromTemplate(vm.selectedTemplate)" ng-disabled="!vm.selectedTemplate") Create Session
-                        div.hspace-double
-                        button.btn.btn-secondary.btn-link(ng-click="vm.editTemplate()" ng-disabled="!vm.selectedTemplate") Edit Template
-                        div.vspace-double
-                        //- Info box for when there's no templates to show
-                        div.info-box(style="margin: 20px" ng-show='!vm.isLoadingTemplateInfo && !vm.templates.length' ng-cloak)
-                            i.icon.fa.fa-info-circle
-                            span No templates were found. Test session templates are YAML files located in the "templates" subdirectory of your test repo. They allow you to predefine a set of tests to run, along with other options on how you want to create your test session (session label, environment, test actor tags, etc.). For more information, please see the documentation.
-                        //- Progress indicator
-                        div.progress-indicator(ng-show='vm.isLoadingTemplateInfo')
-                            div.img
+                        div.row
+                            button.btn.btn-secondary(ng-click="vm.createSessionFromTemplate(vm.selectedTemplate)" ng-disabled="!vm.selectedTemplate") Create Session
+                            div.hspace-double
+                            button.btn.btn-secondary.btn-link(ng-click="vm.editTemplate()" ng-disabled="!vm.selectedTemplate") Edit Template
+                            div.vspace-double
+                            //- Info box for when there's no templates to show
+                            div.info-box(style="margin: 20px" ng-show='!vm.isLoadingTemplateInfo && !vm.templates.length' ng-cloak)
+                                i.icon.fa.fa-info-circle
+                                span No templates were found. Test session templates are YAML files located in the "templates" subdirectory of your test repo. They allow you to predefine a set of tests to run, along with other options on how you want to create your test session (session label, environment, test actor tags, etc.). For more information, please see the documentation.
+                            //- Progress indicator
+                            div.progress-indicator(ng-show='vm.isLoadingTemplateInfo')
+                                div.img
+                        div.row(style="padding-top: 15px; padding-bottom: 10px")
+                            div.col-md-6
+                                div
+                                    i.fas.fa-search(style="font-size: 16px; margin-left: 3px; margin-top: 10px; position: absolute; z-index: 999")
+                                    input.form-control.search-test(type="text" ng-model="vm.templateSearchText" placeholder="Search" title="Search")
+                                    a(type="button" href="#" ng-click="vm.templateSearchText = ''" ng-show="vm.templateSearchText" style="position: absolute;top: 0px; right: 0px; opacity: 0.7; font-size: 1.5em; width: 15px") ×
                         table.table.table-condensed.table-hover(ng-cloak ng-hide="!vm.templates.length" style="table-layout: fixed; word-wrap: break-word; margin-bottom: 0px")
                             thead
                                 tr
@@ -97,7 +104,7 @@ html
                                     th Template path
                                     th Description
                             tbody
-                                tr(ng-repeat="template in vm.templates")
+                                tr(ng-repeat="template in vm.filteredTemplates = (vm.templates | filter: { name: vm.templateSearchText })")
                                     td
                                         input(type="radio" name="template" id="{{'template'+$index}}" class="template" ng-model="vm.selectedTemplate" ng-value="template")
                                     td
@@ -124,7 +131,7 @@ html
                             div.vspace-double
                             div.row
                                 div.col-md-6
-                                    
+
                                     div.form-group
                                         input.form-control(type="text" ng-model="vm.sessionLabel" placeholder="Session label" title="Session label")
                                 div.col-md-6
@@ -188,9 +195,9 @@ html
         script(src=`${urlPrefix}/js/ng/ng-app.js`)
         script(src=`${urlPrefix}/js/ng/root-ctrl.js`)
         script(src=`${urlPrefix}/socket.io/socket.io.js`)
-        
+
         script.
-            // Highlight the UI tab that corresponds to the current location 
+            // Highlight the UI tab that corresponds to the current location
             $('a[href="' + this.location.pathname + '"]').parents('li,ul').addClass('active');
 
         block body_footer


### PR DESCRIPTION
Currently, in OpenTest Test Session Creation from template page there's no search bar in the test creation page. The user today needs to use the browser search functionality or scroll to find the desired template.
A search bar was added to the template modal in a similar manner to how it was implemented on the regular test session creation modal.