### PR TITLE
Prevent NullPointerException when toString on resultSet field

### DIFF
--- a/actor/base/src/main/java/org/getopentest/actions/db/JdbcQuery.java
+++ b/actor/base/src/main/java/org/getopentest/actions/db/JdbcQuery.java
@@ -43,16 +43,17 @@ public class JdbcQuery extends TestAction {
             while (resultSet.next()) {
                 Map<String, Object> row = new HashMap<>();
                 for (int columnNo = 1; columnNo <= columnCount; columnNo++) {
+                    Object field = resultSet.getObject(columnNo);
                     switch (rsMetaData.getColumnType(columnNo)) {
                         case Types.DATE:
                         case Types.TIME:
                         case Types.TIME_WITH_TIMEZONE:
                         case Types.TIMESTAMP:
                         case Types.TIMESTAMP_WITH_TIMEZONE:
-                            row.put(rsMetaData.getColumnName(columnNo), resultSet.getObject(columnNo).toString());
+                            row.put(rsMetaData.getColumnName(columnNo), resultSet.wasNull() ? null : field.toString());
                             break;
                         default:
-                            row.put(rsMetaData.getColumnName(columnNo), resultSet.getObject(columnNo));
+                            row.put(rsMetaData.getColumnName(columnNo), field);
                     }
                 }
                 rows.add(row);


### PR DESCRIPTION
Hi,
This is to correct the issue reported in https://github.com/mcdcorp/opentest/issues/636

I'm open to colaborate for the improvement of the tool
It is very usefull for our company 

Regards,
Edgar