### PR TITLE
log session start time with time zone abbreviation

### DIFF
--- a/server/src/lib/session-helper.ts
+++ b/server/src/lib/session-helper.ts
@@ -513,10 +513,14 @@ export async function createSession(sessionProps: TestSessionProperties): Promis
             }
 
             async function startTestSession() {
-                log.info(helpers.format('Session {0} with label "{1}" started at {2} UTC',
+                var tzname = moment.tz.guess();
+                var zonename = moment.tz(tzname).zoneAbbr();
+                log.info(helpers.format('Session {0} with label "{1}" started at {2} {3}',
                     sessionId,
                     sessionProps.sessionLabel,
-                    moment().utc().format('YYYY-MM-DD HH:mm:ss')));
+                    moment().format('YYYY-MM-DD HH:mm:ss'),
+                    zonename
+                ));
 
                 await db.updateSession(sessionId, {
                     actors: sessionActors,


### PR DESCRIPTION
This implements the changes suggested in #650